### PR TITLE
Add editable tables and new creator entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Streamlit app helps manage your YouTube/TikTok creator and prospect roster.
 - Tag creators by verticals and demographics
 - Export roster as CSV
 - Prospects and creators displayed in separate tables
+- Edit roster entries directly in the tables
 
 ## Run Locally
 

--- a/app.py
+++ b/app.py
@@ -218,6 +218,36 @@ if "creators" not in st.session_state:
             "Channel URL": "https://www.youtube.com/@JustAli",
             "Monthly Views (Long Form)": 418900,
         },
+        {
+            "Name": "Eeowna",
+            "Status": "Creator",
+            "Channel URL": "",
+            "Monthly Views (Long Form)": 0,
+        },
+        {
+            "Name": "Pencilmation",
+            "Status": "Creator",
+            "Channel URL": "",
+            "Monthly Views (Long Form)": 0,
+        },
+        {
+            "Name": "TaylorR1488",
+            "Status": "Creator",
+            "Channel URL": "",
+            "Monthly Views (Long Form)": 0,
+        },
+        {
+            "Name": "Jaclyn Glenn",
+            "Status": "Creator",
+            "Channel URL": "",
+            "Monthly Views (Long Form)": 0,
+        },
+        {
+            "Name": "Kat Buno",
+            "Status": "Creator",
+            "Channel URL": "",
+            "Monthly Views (Long Form)": 0,
+        },
     ]
 
     st.session_state.creators = pd.concat(
@@ -275,16 +305,24 @@ with st.sidebar.form("add_creator"):
 creators_df = st.session_state.creators
 
 st.header("Creator Roster")
-st.dataframe(
-    creators_df[creators_df["Status"] == "Creator"],
+creator_idx = creators_df[creators_df["Status"] == "Creator"].index
+edited_creators = st.data_editor(
+    creators_df.loc[creator_idx],
+    num_rows="dynamic",
     use_container_width=True,
+    key="creator_table",
 )
+st.session_state.creators.loc[creator_idx] = edited_creators
 
 st.header("Prospect Roster")
-st.dataframe(
-    creators_df[creators_df["Status"] == "Prospect"],
+prospect_idx = creators_df[creators_df["Status"] == "Prospect"].index
+edited_prospects = st.data_editor(
+    creators_df.loc[prospect_idx],
+    num_rows="dynamic",
     use_container_width=True,
+    key="prospect_table",
 )
+st.session_state.creators.loc[prospect_idx] = edited_prospects
 
 # Export to CSV
 st.download_button(


### PR DESCRIPTION
## Summary
- allow editing table data using `st.data_editor`
- add Eeowna, Pencilmation, TaylorR1488, Jaclyn Glenn and Kat Buno as creators
- update features list with new editing capability

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688be01777e483318e0916183ff76ec6