### PR TITLE
Enable tag categories and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This Streamlit app helps manage your YouTube/TikTok creator and prospect roster.
 
 - Add/remove creators or prospects
 - Store audience and brand preference data
+- Capture preferred and avoided brand categories
 - Tag creators by verticals and demographics
+- Filter entries by verticals or brand categories
 - Export roster as CSV
 - Prospects and creators displayed in separate tables
 - Edit roster entries directly in the tables


### PR DESCRIPTION
## Summary
- normalize and display tag fields
- add preferred/avoided brand category columns
- support filters for verticals and brand categories
- document new feature

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688bed7580d483319735b045499b5b99