### PR TITLE
Improve table editing and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Streamlit app helps manage your YouTube/TikTok creator and prospect roster.
 - Capture preferred and avoided brand categories
 - Tag creators by verticals and demographics
 - Filter entries by verticals or brand categories
+- Optional column filters and search
 - Export roster as CSV
 - Prospects and creators displayed in separate tables
 - Edit roster entries directly in the tables


### PR DESCRIPTION
## Summary
- allow filtering by any column with optional search bar
- document filtering in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688bf140222c83319dcdacf22c8916bf